### PR TITLE
Remove react and react-native dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,5 @@
   "bugs": {
     "url": "https://github.com/fixt/react-native-digits/issues"
   },
-  "homepage": "https://github.com/fixt/react-native-digits",
-  "dependencies": {
-    "react": "^15.0.2",
-    "react-native": "^0.26.0"
-  }
+  "homepage": "https://github.com/fixt/react-native-digits"
 }


### PR DESCRIPTION
this enable this package to be used with any version of react-native

this is need because react-native packager uses @providesModule syntax,
then if we use different versions of react-native for the main project
from this package, there will be a conflict

fix fixt/react-native-digits#8
