### PR TITLE
change deps to peerDeps and update ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "url": "https://github.com/fixt/react-native-digits/issues"
   },
   "homepage": "https://github.com/fixt/react-native-digits",
-  "dependencies": {
-    "react": "^15.0.2",
-    "react-native": "^0.26.0"
+  "peerDependencies": {
+    "react": "0.14.x || 15.x.x",
+    "react-native": ">=0.18.0 <=0.29.0"
   }
 }


### PR DESCRIPTION
Related to https://github.com/fixt/react-native-digits/issues/8

Update deps to peerDeps so that only warnings are provided if a peerDependency is not met. Dependencies are based on versions we have tested against and future versions we can reasonably expect to not break anything.

@cgarvis @madwed 
